### PR TITLE
Feat/fix auth state not being reset on cancellation

### DIFF
--- a/src/main/kotlin/com/safehill/kclient/controllers/UserInteractionController.kt
+++ b/src/main/kotlin/com/safehill/kclient/controllers/UserInteractionController.kt
@@ -187,7 +187,7 @@ class UserInteractionController internal constructor(
         phoneNumbersToAdd: List<String> = listOf(),
         phoneNumbersToRemove: List<String> = listOf()
     ): Result<Unit> {
-        val currentThread: ConversationThreadOutputDTO
+        var currentThread: ConversationThreadOutputDTO? = null
         return runCatchingSafe {
             val currentUser = userProvider.get()
             currentThread = serverProxy.retrieveThread(threadId = threadId)
@@ -209,7 +209,7 @@ class UserInteractionController internal constructor(
                 phoneNumbersToRemove = phoneNumbersToRemove
             )
         }.recoverCatching { exception ->
-            if (exception is SafehillError.ClientError.Conflict) {
+            if (exception is SafehillError.ClientError.Conflict && currentThread != null) {
                 with(currentThread) {
                     val newUserIdentifiers = membersPublicIdentifier.toSet()
                         .plus(usersToAdd.map { it.identifier })

--- a/src/main/kotlin/com/safehill/kclient/util/Utils.kt
+++ b/src/main/kotlin/com/safehill/kclient/util/Utils.kt
@@ -30,3 +30,11 @@ suspend inline fun <T> safeApiCall(crossinline invoke: suspend () -> T): Result<
         }
     }
 }
+
+@OptIn(ExperimentalContracts::class)
+fun Throwable.isCancellationException(): Boolean {
+    contract {
+        returns(true) implies (this@isCancellationException is kotlinx.coroutines.CancellationException)
+    }
+    return (this is CancellationException)
+}

--- a/src/main/kotlin/com/safehill/kclient/util/Utils.kt
+++ b/src/main/kotlin/com/safehill/kclient/util/Utils.kt
@@ -11,7 +11,7 @@ inline fun <T> runCatchingSafe(
     block: () -> T
 ): Result<T> {
     contract {
-        callsInPlace(block, kotlin.contracts.InvocationKind.EXACTLY_ONCE)
+        callsInPlace(block, kotlin.contracts.InvocationKind.AT_MOST_ONCE)
     }
     return try {
         Result.success(block())

--- a/src/main/kotlin/com/safehill/safehillclient/SafehillClient.kt
+++ b/src/main/kotlin/com/safehill/safehillclient/SafehillClient.kt
@@ -4,6 +4,7 @@ import com.safehill.kclient.models.LocalCryptoUser
 import com.safehill.kclient.models.users.LocalUser
 import com.safehill.kclient.models.users.ServerUser
 import com.safehill.kclient.network.api.auth.AuthApi
+import com.safehill.kclient.util.isCancellationException
 import com.safehill.kclient.util.runCatchingSafe
 import com.safehill.safehillclient.data.user.api.DefaultUserObserverRegistry
 import com.safehill.safehillclient.data.user.api.UserObserverRegistry
@@ -82,7 +83,7 @@ class SafehillClient(
     }
 
     private suspend fun signInInternal(user: LocalUser): Result<SignInResponse.Success> {
-        return runCatchingSafe {
+        return runCatching {
             authStateHolder.setAuthState(AuthState.Loading)
             val response = authApi.signIn(user = user)
             user.authenticate(response.user, response)
@@ -99,6 +100,7 @@ class SafehillClient(
             )
         }.onFailure {
             authStateHolder.setAuthState(AuthState.SignedOff)
+            if (it.isCancellationException()) throw it
         }
     }
 


### PR DESCRIPTION
- Fix invocation kind of runCatchingSafe to AT_MOST_ONCE.
- FIx auth state stuck on loading if CancellationException is thrown.